### PR TITLE
修复7寸和8寸视频问题

### DIFF
--- a/SunMath/res/layout/quiz_fill_in_flipper_child.xml
+++ b/SunMath/res/layout/quiz_fill_in_flipper_child.xml
@@ -22,7 +22,9 @@
                   android:gravity="center_vertical"
                   android:layout_alignParentBottom="true"
                   android:orientation="horizontal">
-        <TextView android:layout_width="wrap_content"
+        <TextView 
+            	  android:id="@+id/quiz_fill_in_flipper_child_str"
+            	  android:layout_width="wrap_content"
                   android:layout_height="wrap_content"
                   android:textColor="@color/green"
                   android:textSize="22sp"

--- a/SunMath/src/com/ssl/curriculum/math/activity/MainActivity.java
+++ b/SunMath/src/com/ssl/curriculum/math/activity/MainActivity.java
@@ -117,17 +117,4 @@ System.out.println("Main's quiz_num="+quiz_num);
     	mActivityViewer.pause();
     }
     
-    @Override
-    protected void onResume() {
-    	// TODO Auto-generated method stub
-    	super.onResume();
-    	this.registerReceiver(new BroadcastReceiver(){
-
-			@Override
-			public void onReceive(Context arg0, Intent arg1) {
-				// TODO Auto-generated method stub
-				System.out.println("收到广播");
-				mActivityViewer.onNextBtnClicked(rightBtn);
-			}}, new IntentFilter("com.liucong.next"));
-    }
 }

--- a/SunMath/src/com/ssl/curriculum/math/component/activity/VideoActivityView.java
+++ b/SunMath/src/com/ssl/curriculum/math/component/activity/VideoActivityView.java
@@ -21,7 +21,7 @@ public class VideoActivityView extends ActivityView {
         initUI();
     }
 
-    @Override
+     @Override
     public void setActivity(LinkedActivityData activityData) {
         super.setActivity(activityData);
         setTitle(activityData.name);

--- a/SunMath/src/com/ssl/curriculum/math/component/quiz/FillBlankQuestionView.java
+++ b/SunMath/src/com/ssl/curriculum/math/component/quiz/FillBlankQuestionView.java
@@ -20,6 +20,7 @@ import com.ssl.curriculum.math.presenter.quiz.FillBlankQuestionPresenter;
 
 public class FillBlankQuestionView extends QuizQuestionView implements QuestionResultListener {
     private TextView showAnswerField;
+    private TextView answerStr;
     private EditText answerEditText;
     private QuizQuestion mQuestion;
     //private QuizComponentViewer mQuizViewer;
@@ -56,6 +57,7 @@ public class FillBlankQuestionView extends QuizQuestionView implements QuestionR
         addView(viewGroup);
         questionWebView = (WebView) findViewById(R.id.quiz_fill_in_flipper_child_question);
         showAnswerField = (TextView) findViewById(R.id.quiz_fill_in_showAnswerField);
+        answerStr = (TextView) findViewById(R.id.quiz_fill_in_flipper_child_str);
         answerEditText = (EditText) findViewById(R.id.quiz_fill_in_flipper_child_answer);
         progressBar = (ProgressBar) findViewById(R.id.quiz_fill_in_progress_bar);
         questionTitle = (TextView) findViewById(R.id.quiz_fill_in_flipper_child_title);
@@ -104,7 +106,8 @@ System.out.println("HelloWorld");
     }
 
     public void setShowAnswerText(String text) {
-        showAnswerField.setText(text);
+       showAnswerField.setText(text);
+    	answerStr.setVisibility(View.INVISIBLE);
     }
 
     @Override


### PR DESCRIPTION
1.8寸上面点击视频直接全屏且自动播放，对于来回切换还是有些卡顿，但已经不会轻易crash
2.7寸上可以播放视频，但是还不能全屏播放
3.当做完一个Activity的全部题后，点击“下一节”进入视频还是不能播放，需要退出来点击对应的视频才能播放——这是一个很不好的地方
